### PR TITLE
Cross pod communication to gRPC server for FT job

### DIFF
--- a/bin/start-grpc-server.py
+++ b/bin/start-grpc-server.py
@@ -4,11 +4,12 @@ import logging
 import grpc
 from ft.proto import fine_tuning_studio_pb2_grpc
 from ft.service import FineTuningStudioApp
+from ft.consts import DEFAULT_FTS_GRPC_PORT
 from multiprocessing import Process
 import socket 
 
 def start_server(blocking: bool = False):
-    port = "50051"
+    port = DEFAULT_FTS_GRPC_PORT
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     fine_tuning_studio_pb2_grpc.add_FineTuningStudioServicer_to_server(FineTuningStudioApp(), server=server)
     server.add_insecure_port("[::]:" + port)
@@ -18,16 +19,8 @@ def start_server(blocking: bool = False):
     if blocking:
         server.wait_for_termination()
 
-def is_port_in_use(port: int) -> bool:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        result = sock.connect_ex(('localhost', port))
-        return result == 0
-    
-    
-port = 50051
-if not is_port_in_use(port):
-    print("Starting up the gRPC server.")
-    # Start the gRPC server if it's not already running
-    start_server(blocking=True)
-else:
-    print("Server is already running.")
+
+# Start the server up. If this command fails (if the port is already
+# in use), the application script bin/start-app-script.sh will continue
+# to run and the error will exit gracefully.
+start_server(blocking=True)

--- a/ft/client.py
+++ b/ft/client.py
@@ -3,6 +3,7 @@ import grpc
 
 from ft.api import *
 from ft.proto.fine_tuning_studio_pb2_grpc import FineTuningStudioStub
+from ft.consts import DEFAULT_FTS_GRPC_PORT
 
 from typing import List
 
@@ -18,8 +19,8 @@ class FineTuningStudioClient(FineTuningStudioStub):
     access all standard stub requests as needed in "proper" request/response format.
     """
 
-    def __init__(self):
-        self.channel = grpc.insecure_channel('localhost:50051')
+    def __init__(self, server_ip: str = "localhost", server_port: str = DEFAULT_FTS_GRPC_PORT):
+        self.channel = grpc.insecure_channel(f"{server_ip}:{server_port}")
         self.stub = FineTuningStudioStub.__init__(self, self.channel)
 
     def get_state(self) -> AppState:

--- a/ft/consts.py
+++ b/ft/consts.py
@@ -1,1 +1,2 @@
 HF_LOGO = "https://huggingface.co/datasets/huggingface/brand-assets/resolve/main/hf-logo.png"
+DEFAULT_FTS_GRPC_PORT = "50051"


### PR DESCRIPTION
## Access FTS gRPC server in Fine Tuning worker Job

Now that we have a running gRPC server to handle application requests, once we spawn new fine tuning/training jobs, we can get access to that server. This simplifies things like arguments that are passed to the fine tuning job (we only need to send IDs now, and we can send a request to the gRPC server to extract more information about datasets/models before loading into memory)


## Testing 

Tested on genAI cluster