### PR TITLE
Add adapter remove functionality

### DIFF
--- a/pgs/view_models.py
+++ b/pgs/view_models.py
@@ -76,11 +76,17 @@ def display_adapter(adapter: AdapterMetadata, container):
         c1.text(adapter.name)
         if adapter.type == AdapterType.ADAPTER_TYPE_PROJECT:
             c1.caption(adapter.location)
+        elif adapter.type == AdapterType.ADAPTER_TYPE_HUGGINGFACE:
+            c1.caption(adapter.huggingface_name)
 
         remove = c2.button("Remove", type="secondary", key=f"{adapter.id}_remove", use_container_width=True)
 
         if remove:
-            st.toast("You can't do that yet.", icon=":material/info:")
+            fts.RemoveAdapter(
+                RemoveAdapterRequest(
+                    id=adapter.id
+                )
+            )
 
 
 display_header()


### PR DESCRIPTION
## Remove adapters from UI

* we can now remove adapters with the gRPC client. This update allows for the adapter "Remove" function to actually remove adapter metadata from the app state.
* This doesn't actually remove adapter files from the project file store, and it doesn't remove training jobs from the list of ongoing/completed jobs.