### PR TITLE
Script to compile SQLite3 CLI into project

### DIFF
--- a/bin/get-sqlite.sh
+++ b/bin/get-sqlite.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd ~
+rm -rf sqlite3/
+mkdir -p sqlite3/
+cd sqlite3/
+wget https://www.sqlite.org/2024/sqlite-autoconf-3460100.tar.gz
+tar -xzvf sqlite-autoconf-3460100.tar.gz
+cd sqlite-autoconf-3460100
+./configure
+make -j
+echo "export PATH=~/sqlite3/sqlite-autoconf-3460100/:$PATH" >> ~/.bashrc


### PR DESCRIPTION
## Sqlite3 CLI

This script will download sqlite3 CLI source code, compile, and add to path. This will make `sqlite3` CLI tool available from a project session if a user wants to interact with the app's database from the command line.

This is necessary because `sqlite3` doesn't ship natively with CDSW engine runtimes, and we can't install a precompiled binary of `sqlite3` because of a `GLIBC` version mismatch