### PR TITLE
Fix truncation and output issues in eval jobs

### DIFF
--- a/ft/config/model_configs/config_loader.py
+++ b/ft/config/model_configs/config_loader.py
@@ -24,6 +24,15 @@ class ModelMetadataFinder:
             print("Bos token Id can't be found out returning default alpaca ID")
             return 1
 
+    @staticmethod
+    def fetch_eos_token_id_from_config(model_name_or_path):
+        config = AutoConfig.from_pretrained(model_name_or_path)
+        try:
+            return config.eos_token_id
+        except BaseException:
+            print("EOS token Id can't be found out returning default alpaca ID")
+            return 2
+
 
 if __name__ == "__main__":
     model_family_finder = ModelMetadataFinder("nvidia/Mistral-NeMo-Minitron-8B-Base")

--- a/ft/consts.py
+++ b/ft/consts.py
@@ -14,6 +14,10 @@ TRAINING_DEFAULT_TRAIN_TEST_SPLIT = 0.9
 TRAINING_DEFAULT_DATASET_FRACTION = 1.0
 TRAINING_DATASET_SEED = 42
 
+# Evaluation constants
+EVAL_INPUT_COLUMN = "model_input"
+EVAL_OUTPUT_COLUM = "expected_output"
+
 
 class IconPaths:
     class FineTuningStudio:

--- a/ft/eval/mlflow_driver.py
+++ b/ft/eval/mlflow_driver.py
@@ -66,7 +66,11 @@ def driver(
             # Inside try cache to avoid failures with wrong adapters
             peft_model, tokenizer = mlt.get_peft_model_and_tokenizer(
                 base_model.huggingface_model_name, adapter.location, bnb_config_dict)
-            model_info = logger.log_model_multi_gpu(peft_model, tokenizer)
+            model_info = logger.log_model_multi_gpu(
+                peft_model,
+                tokenizer,
+                generation_config_dict,
+                base_model.huggingface_model_name)
         except BaseException:
             # need to improve logic for this. Not sure if this is desired behavior
             raise ValueError("Failed to load peft model. Can run eval on only base model.")

--- a/ft/eval/mlflow_evaluator.py
+++ b/ft/eval/mlflow_evaluator.py
@@ -1,5 +1,7 @@
 import mlflow
 
+from ft.consts import EVAL_INPUT_COLUMN, EVAL_OUTPUT_COLUM
+
 
 class ModelEvaluator():
 
@@ -7,15 +9,15 @@ class ModelEvaluator():
         pass
 
     @staticmethod
-    def evaluate_model(model_info, eval_df, eval_target_column_name="response"):
+    def evaluate_model(model_info, eval_df, eval_target_column_name=EVAL_OUTPUT_COLUM):
         with mlflow.start_run():
             results = mlflow.evaluate(
                 model_info.model_uri,
                 eval_df,
                 evaluators="default",
                 model_type="text",    # parametrize this to support other types such as QnA, summarization etc.
-                targets=eval_target_column_name,
-                evaluator_config={"col_mapping": {"inputs": "model_input"}},
+                targets=None,  # we do not set a target for a text-generation pipeline
+                evaluator_config={"col_mapping": {"inputs": EVAL_INPUT_COLUMN}},
                 extra_metrics=[mlflow.metrics.latency(), mlflow.metrics.exact_match(), mlflow.metrics.rougeLsum(),
                                mlflow.metrics.rougeL()]
             )

--- a/ft/pipeline.py
+++ b/ft/pipeline.py
@@ -83,10 +83,7 @@ def load_adapted_hf_generation_pipeline(
             raise ValueError(f"Error loading Lora model due to error: {e}. Can load base model Only")
 
     model.eval()
-    model.config.pad_token_id = tokenizer.pad_token_id = 0  # unk
-    model.config.bos_token_id = model_metadata_finder.fetch_bos_token_id_from_config(
-        base_model_name)  # Todo: make this dynamic for different configs
-    model.config.eos_token_id = 2
+    tokenizer.pad_token = tokenizer.eos_token
 
     config = GenerationConfig(**gen_config_dict)
     pipe = pipeline(


### PR DESCRIPTION
## Description

* Adds a dynamic EOS token ID finder for Eval model configs
* extracts out eval input and output column to consts
* only feed relevant eval columns to mlflow, not the whole eval set. some dataset feature names (column names) seem to be interfering with mlflow under the hood.
* purposefully eliminate deprecated max_length from model config. max_length was having unexpected truncation consequences under the hood during output (after generation), even though it was being overridden during generation
* remove targes from mlflow.evaluate(), since this was having adverse affects on text generation. Also, technically for text generation tasks there is no "target", although that field can (and is sometimes) used to populate some "reference" text.

## Testing

* tested multiple models and eval jobs